### PR TITLE
Exclude tasks with no status from task_state_time

### DIFF
--- a/master_state.go
+++ b/master_state.go
@@ -215,7 +215,9 @@ func newMasterStateCollector(url string, timeout time.Duration) *masterCollector
 							task.FrameworkID,
 							task.State,
 						}
-						c.(*prometheus.GaugeVec).WithLabelValues(values...).Set(task.Statuses[0].Timestamp)
+						if len(task.Statuses) > 0 {
+							c.(*prometheus.GaugeVec).WithLabelValues(values...).Set(task.Statuses[0].Timestamp)
+						}
 					}
 				}
 			},


### PR DESCRIPTION
These tasks have no timestamp defined, and 0 doesn't seem like a useful substitute timestamp here (I think, at least), so maybe just skip them?

Fixes #6
